### PR TITLE
Implement basic Passometro app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# UTI
+# Passômetro de Casos - UTI
+
+Este é um aplicativo simples em Flask para registrar e acompanhar casos de pacientes em leitos de UTI. A aplicação permite adicionar, visualizar e remover casos, funcionando como um "passômetro" digital para médicos.
+
+## Requisitos
+- Python 3
+- Dependências listadas em `requirements.txt`
+
+## Instalação
+1. Crie um ambiente virtual (opcional, mas recomendado):
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
+2. Instale as dependências:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Uso
+Execute a aplicação com:
+```bash
+python app.py
+```
+Acesse `http://localhost:5000` em seu navegador para usar a interface.
+
+Os casos são armazenados em um banco SQLite (`cases.db`) no próprio diretório.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,47 @@
+from flask import Flask, render_template, request, redirect, url_for
+from flask_sqlalchemy import SQLAlchemy
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///cases.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db = SQLAlchemy(app)
+
+class Case(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    patient_name = db.Column(db.String(100), nullable=False)
+    bed_number = db.Column(db.String(20), nullable=False)
+    diagnosis = db.Column(db.String(200), nullable=False)
+    notes = db.Column(db.Text, nullable=True)
+
+    def __repr__(self):
+        return f"<Case {self.patient_name} - Bed {self.bed_number}>"
+
+@app.route('/')
+def index():
+    cases = Case.query.all()
+    return render_template('index.html', cases=cases)
+
+@app.route('/add', methods=['POST'])
+def add_case():
+    patient_name = request.form['patient_name']
+    bed_number = request.form['bed_number']
+    diagnosis = request.form['diagnosis']
+    notes = request.form.get('notes', '')
+    case = Case(patient_name=patient_name, bed_number=bed_number,
+                diagnosis=diagnosis, notes=notes)
+    db.session.add(case)
+    db.session.commit()
+    return redirect(url_for('index'))
+
+@app.route('/delete/<int:case_id>')
+def delete_case(case_id):
+    case = Case.query.get_or_404(case_id)
+    db.session.delete(case)
+    db.session.commit()
+    return redirect(url_for('index'))
+
+if __name__ == '__main__':
+    with app.app_context():
+        db.create_all()
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+Flask-SQLAlchemy

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Passometro de Casos - UTI</title>
+    <style>
+        body {font-family: Arial, sans-serif; margin: 2em;}
+        table {border-collapse: collapse; width: 100%;}
+        th, td {border: 1px solid #ccc; padding: 8px; text-align: left;}
+        th {background-color: #f2f2f2;}
+        form {margin-bottom: 2em;}
+    </style>
+</head>
+<body>
+    <h1>Passometro de Casos - UTI</h1>
+    <form method="POST" action="/add">
+        <label>Paciente: <input type="text" name="patient_name" required></label><br>
+        <label>Leito: <input type="text" name="bed_number" required></label><br>
+        <label>Diagnóstico: <input type="text" name="diagnosis" required></label><br>
+        <label>Notas:<br><textarea name="notes" rows="4" cols="50"></textarea></label><br>
+        <button type="submit">Adicionar Caso</button>
+    </form>
+    <table>
+        <tr>
+            <th>Paciente</th>
+            <th>Leito</th>
+            <th>Diagnóstico</th>
+            <th>Notas</th>
+            <th>Ação</th>
+        </tr>
+        {% for case in cases %}
+        <tr>
+            <td>{{ case.patient_name }}</td>
+            <td>{{ case.bed_number }}</td>
+            <td>{{ case.diagnosis }}</td>
+            <td>{{ case.notes }}</td>
+            <td><a href="{{ url_for('delete_case', case_id=case.id) }}">Excluir</a></td>
+        </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create simple Flask app for ICU case handoff
- add SQLAlchemy models and CRUD routes
- provide HTML interface for adding and listing cases
- document usage in Portuguese

## Testing
- `pip install -r requirements.txt`
- `python app.py` (started development server)

------
https://chatgpt.com/codex/tasks/task_e_6843e16483f083319a7a73829e6eb0b1