### PR TITLE
Add CalDAV export to iCloud for optimized shifts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,75 @@
-# UTI
+# UTI – Otimizador de agenda de plantão
+
+Este repositório contém uma ferramenta em Python para auxiliar na distribuição
+balanceada de plantões. A heurística implementada considera restrições comuns
+(como descanso mínimo entre turnos, indisponibilidades e número máximo de
+plantões por pessoa) e tenta atender preferências individuais sempre que
+possível.
+
+## Como funciona
+
+1. Prepare um arquivo de configuração em JSON (ou YAML) com a descrição dos
+   plantões e a lista de profissionais elegíveis. Veja o arquivo
+   [`exemplos/escala_exemplo.json`](exemplos/escala_exemplo.json) como ponto de
+   partida.
+2. Execute o otimizador informando o caminho para o arquivo de configuração:
+
+   ```bash
+   python -m plantao_optimizer.optimizer exemplos/escala_exemplo.json --iterations 600 --seed 42
+   ```
+
+3. Opcionalmente, salve o resultado em JSON usando `--dump-json`.
+
+A saída apresenta um resumo com a quantidade de plantões por profissional, as
+respectivas datas atribuídas, a sequência máxima de dias consecutivos trabalhados
+e a pontuação da solução (quanto menor, melhor).
+
+## Instalação
+
+A aplicação depende apenas da biblioteca padrão do Python. Recursos adicionais
+são opcionais e podem ser instalados conforme a necessidade:
+
+- **YAML**: `pip install pyyaml`
+- **Integração com iCloud (CalDAV)**: `pip install caldav`
+
+Caso utilize timezones específicos, assegure-se de que o sistema possui os
+dados de fuso horário atualizados (em distribuições Linux geralmente já estão
+presentes; no Windows recomenda-se instalar o pacote `tzdata`).
+
+## Integração com agenda do iCloud
+
+É possível enviar automaticamente o resultado otimizado para um calendário do
+iCloud usando o protocolo CalDAV. Siga os passos:
+
+1. Gere uma senha específica de app na sua conta Apple ID.
+2. Identifique o nome exato do calendário que receberá os eventos.
+3. Execute o otimizador informando as credenciais:
+
+   ```bash
+   python -m plantao_optimizer.optimizer exemplos/escala_exemplo.json \
+       --icloud-user "seu_usuario@icloud.com" \
+       --icloud-app-password "SENHA-DO-APP" \
+       --icloud-calendar "Plantões" \
+       --icloud-timezone America/Sao_Paulo
+   ```
+
+   As credenciais também podem ser fornecidas via variáveis de ambiente:
+
+   - `PLANTAO_ICLOUD_USER`
+   - `PLANTAO_ICLOUD_APP_PASSWORD`
+   - `PLANTAO_ICLOUD_CALENDAR`
+   - `PLANTAO_ICLOUD_SERVER` (opcional, padrão `https://caldav.icloud.com/`)
+   - `PLANTAO_ICLOUD_TIMEZONE` (opcional)
+
+4. Por padrão, eventos previamente criados com o mesmo identificador de
+   plantão serão substituídos. Use `--icloud-keep-existing` caso deseje manter
+   os eventos existentes.
+
+## Próximos passos sugeridos
+
+- Ajustar penalidades e pesos para aproximar o comportamento das regras
+  reais da escala.
+- Adicionar novas restrições (folgas fixas, número mínimo de noites por mês,
+  etc.).
+- Implementar testes automatizados com cenários típicos do plantão.
+

--- a/exemplos/escala_exemplo.json
+++ b/exemplos/escala_exemplo.json
@@ -1,0 +1,37 @@
+{
+  "min_rest_hours": 12,
+  "max_consecutive_days": 3,
+  "shifts": [
+    {"id": "2024-03-01-dia", "start": "2024-03-01T07:00:00", "end": "2024-03-01T19:00:00", "skills": ["uti"]},
+    {"id": "2024-03-01-noite", "start": "2024-03-01T19:00:00", "end": "2024-03-02T07:00:00", "skills": ["uti"]},
+    {"id": "2024-03-02-dia", "start": "2024-03-02T07:00:00", "end": "2024-03-02T19:00:00", "skills": ["uti"]},
+    {"id": "2024-03-02-noite", "start": "2024-03-02T19:00:00", "end": "2024-03-03T07:00:00", "skills": ["uti"]},
+    {"id": "2024-03-03-dia", "start": "2024-03-03T07:00:00", "end": "2024-03-03T19:00:00", "skills": ["uti"]}
+  ],
+  "professionals": [
+    {
+      "name": "Ana",
+      "skills": ["uti"],
+      "max_shifts": 4,
+      "preferred": ["2024-03-01", "2024-03-03"],
+      "undesired": ["2024-03-02"],
+      "unavailable": ["2024-03-04"]
+    },
+    {
+      "name": "Bruno",
+      "skills": ["uti"],
+      "max_shifts": 3,
+      "preferred": ["2024-03-02"],
+      "undesired": [],
+      "unavailable": ["2024-03-01"]
+    },
+    {
+      "name": "Clara",
+      "skills": ["uti"],
+      "max_shifts": 3,
+      "preferred": ["2024-03-01", "2024-03-02"],
+      "undesired": ["2024-03-03"],
+      "unavailable": []
+    }
+  ]
+}

--- a/plantao_optimizer/__init__.py
+++ b/plantao_optimizer/__init__.py
@@ -1,0 +1,67 @@
+"""Ferramentas para otimização de agenda de plantão."""
+
+from __future__ import annotations
+
+from os import PathLike
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .optimizer import OptimizationResult as OptimizationResultType
+    from .icloud import ICloudConfig as ICloudConfigType
+
+__all__ = [
+    "OptimizationResult",
+    "load_configuration",
+    "optimize_schedule",
+    "ICloudConfig",
+    "load_icloud_config_from_env",
+    "push_result_to_icloud",
+    "ICloudIntegrationError",
+]
+
+
+def load_configuration(path: str | PathLike[str]) -> Dict[str, Any]:
+    from .optimizer import load_configuration as _load_configuration
+
+    return _load_configuration(path)
+
+
+def optimize_schedule(*args: Any, **kwargs: Any):
+    from .optimizer import optimize_schedule as _optimize_schedule
+
+    return _optimize_schedule(*args, **kwargs)
+
+
+def __getattr__(name: str):  # pragma: no cover - encaminhamento dinâmico
+    if name == "OptimizationResult":
+        from .optimizer import OptimizationResult
+
+        return OptimizationResult
+    if name == "ICloudConfig":
+        from .icloud import ICloudConfig
+
+        return ICloudConfig
+    if name == "ICloudIntegrationError":
+        from .icloud import ICloudIntegrationError
+
+        return ICloudIntegrationError
+    raise AttributeError(name)
+
+
+def load_icloud_config_from_env() -> Optional["ICloudConfigType"]:
+    from .icloud import load_config_from_env as _load
+
+    return _load()
+
+
+def push_result_to_icloud(
+    result: "OptimizationResultType",
+    config: "ICloudConfigType",
+    *,
+    timezone_name: Optional[str] = None,
+    clear_existing: bool = True,
+) -> int:
+    from .icloud import connect as _connect, export_result as _export
+
+    calendar = _connect(config)
+    return _export(result, calendar, timezone_name=timezone_name, clear_existing=clear_existing)

--- a/plantao_optimizer/icloud.py
+++ b/plantao_optimizer/icloud.py
@@ -1,0 +1,165 @@
+"""Integração opcional com calendários do iCloud via CalDAV."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import os
+import uuid
+from typing import Iterable, Optional
+
+try:  # Dependência opcional
+    import caldav  # type: ignore
+except Exception:  # pragma: no cover - caso sem caldav instalado
+    caldav = None
+
+from .optimizer import OptimizationResult, Shift
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover - compatibilidade Python < 3.9
+    ZoneInfo = None  # type: ignore
+
+
+class ICloudIntegrationError(RuntimeError):
+    """Erro lançado quando a integração com o iCloud falha."""
+
+
+@dataclass
+class ICloudConfig:
+    """Parâmetros necessários para conectar ao iCloud."""
+
+    username: str
+    app_password: str
+    calendar: str
+    server_url: str = "https://caldav.icloud.com/"
+
+
+def _require_caldav() -> None:
+    if caldav is None:  # pragma: no cover - apenas quando a dependência não está presente
+        raise ICloudIntegrationError(
+            "Integração indisponível: instale o pacote 'caldav' para usar o iCloud."
+        )
+
+
+def load_config_from_env() -> Optional[ICloudConfig]:
+    """Cria configuração a partir de variáveis de ambiente padrão."""
+
+    username = os.getenv("PLANTAO_ICLOUD_USER")
+    app_password = os.getenv("PLANTAO_ICLOUD_APP_PASSWORD")
+    calendar = os.getenv("PLANTAO_ICLOUD_CALENDAR")
+
+    if not (username and app_password and calendar):
+        return None
+
+    server_url = os.getenv("PLANTAO_ICLOUD_SERVER", "https://caldav.icloud.com/")
+    return ICloudConfig(username=username, app_password=app_password, calendar=calendar, server_url=server_url)
+
+
+def connect(config: ICloudConfig) -> "caldav.Calendar":
+    """Retorna o calendário solicitado no iCloud."""
+
+    _require_caldav()
+    client = caldav.DAVClient(url=config.server_url, username=config.username, password=config.app_password)
+    principal = client.principal()
+
+    calendars = principal.calendars()
+    for calendar in calendars:
+        if calendar.name == config.calendar:
+            return calendar
+
+    raise ICloudIntegrationError(
+        "Calendário não encontrado. Crie-o previamente no iCloud ou ajuste o nome informado."
+    )
+
+
+def _localize(dt: datetime, tz_name: Optional[str]) -> datetime:
+    if tz_name is None:
+        return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+    if ZoneInfo is None:
+        raise ICloudIntegrationError(
+            "zoneinfo indisponível neste interpretador. Utilize Python 3.9+ ou forneça datetimes com timezone."
+        )
+
+    tz = ZoneInfo(tz_name)
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=tz)
+    return dt.astimezone(tz)
+
+
+def _format_dt(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _build_event(professional: str, shift: Shift, tz_name: Optional[str]) -> str:
+    start = _localize(shift.start, tz_name)
+    end = _localize(shift.end, tz_name)
+    uid = f"{shift.identifier}-{uuid.uuid4()}@plantao-optimizer"
+    dtstamp = _format_dt(datetime.utcnow().replace(tzinfo=timezone.utc))
+    dtstart = _format_dt(start)
+    dtend = _format_dt(end)
+    summary = f"Plantão - {professional}"
+    description = (
+        f"Profissional: {professional}\n"
+        f"Início: {start.isoformat()}\n"
+        f"Fim: {end.isoformat()}\n"
+        f"ID do plantão: {shift.identifier}"
+    )
+
+    return (
+        "BEGIN:VCALENDAR\n"
+        "VERSION:2.0\n"
+        "PRODID:-//plantao-optimizer//iCloud//PT-BR\n"
+        "BEGIN:VEVENT\n"
+        f"UID:{uid}\n"
+        f"DTSTAMP:{dtstamp}\n"
+        f"DTSTART:{dtstart}\n"
+        f"DTEND:{dtend}\n"
+        f"SUMMARY:{summary}\n"
+        f"DESCRIPTION:{description}\n"
+        f"X-PLANTAO-ID:{shift.identifier}\n"
+        "END:VEVENT\n"
+        "END:VCALENDAR\n"
+    )
+
+
+def remove_existing_events(calendar: "caldav.Calendar", shift_ids: Iterable[str]) -> None:
+    """Remove eventos que contenham IDs informados no campo X-PLANTAO-ID."""
+
+    _require_caldav()
+    shift_ids = set(shift_ids)
+    if not shift_ids:
+        return
+
+    for event in calendar.events():  # pragma: no branch - loop simples
+        data = getattr(event, "data", "")
+        if not data:
+            continue
+        if any(f"X-PLANTAO-ID:{shift_id}" in data for shift_id in shift_ids):
+            event.delete()
+
+
+def export_result(
+    result: OptimizationResult,
+    calendar: "caldav.Calendar",
+    *,
+    timezone_name: Optional[str] = None,
+    clear_existing: bool = True,
+) -> int:
+    """Exporta o resultado da otimização para o calendário especificado.
+
+    Returns:
+        Número de eventos criados.
+    """
+
+    _require_caldav()
+    if clear_existing:
+        remove_existing_events(calendar, result.assignments.keys())
+
+    created = 0
+    for professional, shift in result.iter_assigned_shifts():
+        ics = _build_event(professional, shift, timezone_name)
+        calendar.save_event(ics)
+        created += 1
+    return created

--- a/plantao_optimizer/optimizer.py
+++ b/plantao_optimizer/optimizer.py
@@ -1,0 +1,519 @@
+"""Ferramenta simples para otimização de escala de plantões.
+
+O módulo fornece uma heurística baseada em busca estocástica para distribuir
+plantões entre profissionais, respeitando restrições básicas como descanso
+mínimo, indisponibilidades e número máximo de plantões. O objetivo é obter uma
+escala equilibrada que respeite preferências e limite sequências longas de
+trabalho.
+
+O algoritmo não garante solução ótima, mas executa múltiplas tentativas com
+ordens diferentes e mantém o melhor resultado encontrado."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta
+import json
+import math
+import os
+import random
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
+
+try:  # YAML é opcional
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - dependência opcional
+    yaml = None
+
+
+@dataclass(frozen=True)
+class Shift:
+    """Representa um plantão a ser preenchido."""
+
+    identifier: str
+    start: datetime
+    end: datetime
+    required_skills: Set[str] = field(default_factory=set)
+    tags: Set[str] = field(default_factory=set)
+
+    @property
+    def duration(self) -> timedelta:
+        return self.end - self.start
+
+    @property
+    def date(self) -> date:
+        return self.start.date()
+
+
+@dataclass
+class Professional:
+    """Profissional elegível para os plantões."""
+
+    name: str
+    skills: Set[str]
+    max_shifts: Optional[int] = None
+    min_rest_hours: Optional[float] = None
+    unavailable: Set[date] = field(default_factory=set)
+    preferred: Set[date] = field(default_factory=set)
+    undesired: Set[date] = field(default_factory=set)
+
+
+@dataclass
+class OptimizationResult:
+    assignments: Dict[str, str]
+    unassigned: List[Shift]
+    per_professional: Dict[str, Dict[str, object]]
+    score: float
+    iterations: int
+    shifts: Dict[str, Shift] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "assignments": self.assignments,
+            "unassigned": [shift.identifier for shift in self.unassigned],
+            "per_professional": self.per_professional,
+            "score": self.score,
+            "iterations": self.iterations,
+        }
+
+    def iter_assigned_shifts(self) -> Iterable[Tuple[str, Shift]]:
+        """Itera sobre os plantões atribuídos com seus respectivos profissionais."""
+
+        for shift_id, professional in self.assignments.items():
+            shift = self.shifts.get(shift_id)
+            if shift is None:
+                continue
+            yield professional, shift
+
+
+def _parse_datetime(value: str) -> datetime:
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError as exc:  # pragma: no cover - validação básica
+        raise ValueError(f"Data/hora inválida: {value!r}") from exc
+
+
+def _parse_date(value: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:  # pragma: no cover - validação básica
+        raise ValueError(f"Data inválida: {value!r}") from exc
+
+
+def load_configuration(path: Path | str) -> Dict[str, object]:
+    """Carrega arquivo de configuração em JSON ou YAML."""
+
+    path = Path(path)
+    raw = path.read_text(encoding="utf-8")
+    if path.suffix.lower() in {".yaml", ".yml"}:
+        if yaml is None:  # pragma: no cover - caso sem PyYAML
+            raise RuntimeError(
+                "PyYAML não está disponível. Instale o pacote para ler arquivos YAML."
+            )
+        data = yaml.safe_load(raw)
+    else:
+        data = json.loads(raw)
+
+    if not isinstance(data, dict):  # pragma: no cover - validação
+        raise ValueError("O arquivo de configuração deve conter um objeto JSON/YAML.")
+
+    return data
+
+
+def _prepare_shifts(raw_shifts: Sequence[Dict[str, object]]) -> List[Shift]:
+    prepared: List[Shift] = []
+    for item in raw_shifts:
+        identifier = str(item["id"]) if "id" in item else None
+        if not identifier:
+            raise ValueError("Cada plantão precisa de um campo 'id'.")
+        start = _parse_datetime(str(item["start"]))
+        end = _parse_datetime(str(item["end"]))
+        if end <= start:
+            raise ValueError(
+                f"O término do plantão '{identifier}' deve ser posterior ao início."
+            )
+        required_skills = set(map(str, item.get("skills", [])))
+        tags = set(map(str, item.get("tags", [])))
+        prepared.append(
+            Shift(
+                identifier=identifier,
+                start=start,
+                end=end,
+                required_skills=required_skills,
+                tags=tags,
+            )
+        )
+    return prepared
+
+
+def _prepare_professionals(raw_professionals: Sequence[Dict[str, object]]) -> List[Professional]:
+    professionals: List[Professional] = []
+    for item in raw_professionals:
+        name = str(item.get("name"))
+        if not name:
+            raise ValueError("Todo profissional precisa de um nome.")
+        skills = set(map(str, item.get("skills", [])))
+        max_shifts = item.get("max_shifts")
+        if max_shifts is not None:
+            max_shifts = int(max_shifts)
+        min_rest_hours = item.get("min_rest_hours")
+        if min_rest_hours is not None:
+            min_rest_hours = float(min_rest_hours)
+
+        unavailable_raw = item.get("unavailable", [])
+        preferred_raw = item.get("preferred", [])
+        undesired_raw = item.get("undesired", [])
+        if isinstance(unavailable_raw, dict):  # compatibilidade com configs antigas
+            unavailable_raw = unavailable_raw.get("dates", [])
+        if isinstance(preferred_raw, dict):
+            preferred_raw = preferred_raw.get("dates", [])
+        if isinstance(undesired_raw, dict):
+            undesired_raw = undesired_raw.get("dates", [])
+
+        unavailable = {_parse_date(str(val)) for val in unavailable_raw}
+        preferred = {_parse_date(str(val)) for val in preferred_raw}
+        undesired = {_parse_date(str(val)) for val in undesired_raw}
+
+        professionals.append(
+            Professional(
+                name=name,
+                skills=skills,
+                max_shifts=max_shifts,
+                min_rest_hours=min_rest_hours,
+                unavailable=unavailable,
+                preferred=preferred,
+                undesired=undesired,
+            )
+        )
+    return professionals
+
+
+def _can_assign(
+    professional: Professional,
+    shift: Shift,
+    assignments: Dict[str, List[Shift]],
+    *,
+    global_rest_hours: float,
+    max_consecutive_days: Optional[int],
+) -> bool:
+    current = assignments.get(professional.name, [])
+    if professional.max_shifts is not None and len(current) >= professional.max_shifts:
+        return False
+
+    if shift.date in professional.unavailable:
+        return False
+
+    if professional.skills and not shift.required_skills.issubset(professional.skills):
+        return False
+
+    last_shift = max(current, key=lambda s: s.end, default=None)
+    min_rest = professional.min_rest_hours or global_rest_hours
+    if last_shift is not None:
+        hours_since_last = (shift.start - last_shift.end).total_seconds() / 3600
+        if hours_since_last < min_rest:
+            return False
+
+    if max_consecutive_days is not None and max_consecutive_days > 0:
+        dates = sorted({s.date for s in current})
+        if not dates:
+            dates = []
+        # adicionar dia atual e verificar sequência
+        dates.append(shift.date)
+        dates = sorted(set(dates))
+        if _longest_consecutive_streak(dates) > max_consecutive_days:
+            return False
+
+    return True
+
+
+def _longest_consecutive_streak(dates: Sequence[date]) -> int:
+    if not dates:
+        return 0
+    longest = 1
+    current = 1
+    for prev, nxt in zip(dates, dates[1:]):
+        if nxt == prev + timedelta(days=1):
+            current += 1
+            longest = max(longest, current)
+        else:
+            current = 1
+    return longest
+
+
+def _evaluate_candidate(
+    professional: Professional,
+    shift: Shift,
+    assignments: Dict[str, List[Shift]],
+    *,
+    fairness_target: float,
+    preference_reward: float,
+    undesired_penalty: float,
+    balance_weight: float,
+) -> float:
+    current = assignments.get(professional.name, [])
+    projected_count = len(current) + 1
+    fairness_diff = projected_count - fairness_target
+    penalty = balance_weight * (fairness_diff**2)
+
+    shift_date = shift.date
+    if professional.preferred and shift_date in professional.preferred:
+        penalty -= preference_reward
+    if professional.undesired and shift_date in professional.undesired:
+        penalty += undesired_penalty
+
+    # incentivar distribuição homogênea de horas
+    total_hours = sum(s.duration.total_seconds() / 3600 for s in current)
+    projected_hours = total_hours + shift.duration.total_seconds() / 3600
+    penalty += 0.02 * projected_hours
+
+    return penalty
+
+
+def _build_result(
+    assignments: Dict[str, List[Shift]],
+    shifts: Sequence[Shift],
+    *,
+    score: float,
+    iterations: int,
+) -> OptimizationResult:
+    assignments_map: Dict[str, str] = {}
+    per_professional: Dict[str, Dict[str, object]] = {}
+    shift_lookup: Dict[str, Shift] = {shift.identifier: shift for shift in shifts}
+
+    for professional, prof_shifts in assignments.items():
+        prof_shifts_sorted = sorted(prof_shifts, key=lambda s: s.start)
+        per_professional[professional] = {
+            "total_shifts": len(prof_shifts_sorted),
+            "total_hours": sum(s.duration.total_seconds() / 3600 for s in prof_shifts_sorted),
+            "dates": [s.date.isoformat() for s in prof_shifts_sorted],
+            "streak_max": _longest_consecutive_streak([s.date for s in prof_shifts_sorted]),
+        }
+        for shift in prof_shifts_sorted:
+            assignments_map[shift.identifier] = professional
+
+    assigned_ids = set(assignments_map)
+    unassigned = [shift for shift in shifts if shift.identifier not in assigned_ids]
+
+    return OptimizationResult(
+        assignments=assignments_map,
+        unassigned=unassigned,
+        per_professional=per_professional,
+        score=score,
+        iterations=iterations,
+        shifts=shift_lookup,
+    )
+
+
+def optimize_schedule(
+    config: Dict[str, object],
+    *,
+    iterations: int = 400,
+    seed: Optional[int] = None,
+    preference_reward: float = 0.8,
+    undesired_penalty: float = 1.5,
+    balance_weight: float = 1.2,
+) -> OptimizationResult:
+    """Executa otimização heurística da agenda.
+
+    Args:
+        config: Configuração carregada via :func:`load_configuration`.
+        iterations: Número de tentativas com ordens distintas para busca da
+            melhor solução.
+        seed: Semente para controlar a aleatoriedade.
+        preference_reward: Redução de penalidade ao atender preferências.
+        undesired_penalty: Penalidade aplicada ao escalar em datas indesejadas.
+        balance_weight: Peso utilizado para balancear quantidade de plantões.
+    """
+
+    raw_shifts = config.get("shifts", [])
+    raw_professionals = config.get("professionals", [])
+    if not isinstance(raw_shifts, Iterable) or not isinstance(raw_professionals, Iterable):
+        raise ValueError("Configuração inválida: campos 'shifts' e 'professionals' são obrigatórios.")
+
+    shifts = _prepare_shifts(list(raw_shifts))
+    professionals = _prepare_professionals(list(raw_professionals))
+
+    if not shifts:
+        raise ValueError("Nenhum plantão informado na configuração.")
+    if not professionals:
+        raise ValueError("Nenhum profissional informado na configuração.")
+
+    min_rest_hours = float(config.get("min_rest_hours", 12))
+    max_consecutive_days = config.get("max_consecutive_days")
+    if max_consecutive_days is not None:
+        max_consecutive_days = int(max_consecutive_days)
+
+    fairness_target = config.get("target_shifts_per_person")
+    if fairness_target is None:
+        fairness_target = len(shifts) / len(professionals)
+    else:
+        fairness_target = float(fairness_target)
+
+    shifts_sorted = sorted(shifts, key=lambda s: (s.start, s.identifier))
+    best_score = math.inf
+    best_assignments: Dict[str, List[Shift]] = {}
+
+    rng = random.Random(seed)
+
+    for iteration in range(iterations):
+        rng.shuffle(shifts_sorted)
+        assignments: Dict[str, List[Shift]] = {prof.name: [] for prof in professionals}
+        score = 0.0
+        unassigned_penalty = 0.0
+
+        for shift in shifts_sorted:
+            candidates: List[Tuple[float, Professional]] = []
+            for professional in professionals:
+                if not _can_assign(
+                    professional,
+                    shift,
+                    assignments,
+                    global_rest_hours=min_rest_hours,
+                    max_consecutive_days=max_consecutive_days,
+                ):
+                    continue
+                candidate_penalty = _evaluate_candidate(
+                    professional,
+                    shift,
+                    assignments,
+                    fairness_target=fairness_target,
+                    preference_reward=preference_reward,
+                    undesired_penalty=undesired_penalty,
+                    balance_weight=balance_weight,
+                )
+                # pequeno ruído para diversificar empates
+                candidate_penalty += rng.random() * 0.01
+                candidates.append((candidate_penalty, professional))
+
+            if not candidates:
+                unassigned_penalty += 5.0
+                continue
+
+            chosen_penalty, chosen_professional = min(candidates, key=lambda item: item[0])
+            assignments[chosen_professional.name].append(shift)
+            score += chosen_penalty
+
+        # penaliza desvios globais de equilíbrio
+        fairness_cost = 0.0
+        for professional in professionals:
+            allocated = len(assignments[professional.name])
+            fairness_cost += (allocated - fairness_target) ** 2
+        total_score = score + fairness_cost + unassigned_penalty
+
+        if total_score < best_score:
+            best_score = total_score
+            best_assignments = {
+                prof: list(shifts_assigned)
+                for prof, shifts_assigned in assignments.items()
+            }
+
+    # refina ordenando cronologicamente para retorno
+    for prof, prof_shifts in best_assignments.items():
+        best_assignments[prof] = sorted(prof_shifts, key=lambda s: s.start)
+
+    return _build_result(best_assignments, shifts, score=best_score, iterations=iterations)
+
+
+def _format_table(result: OptimizationResult) -> str:
+    from textwrap import indent
+
+    lines = ["Resumo da escala otimizada:"]
+    for professional, info in sorted(result.per_professional.items()):
+        lines.append(
+            f"- {professional}: {info['total_shifts']} plantões, "
+            f"{info['total_hours']:.1f} h, sequência máxima {info['streak_max']} dias"
+        )
+        if info["dates"]:
+            dates = ", ".join(info["dates"])
+            lines.append(indent(f"Datas: {dates}", "  "))
+
+    if result.unassigned:
+        unassigned_ids = ", ".join(shift.identifier for shift in result.unassigned)
+        lines.append(f"Plantões não preenchidos: {unassigned_ids}")
+    else:
+        lines.append("Todos os plantões foram preenchidos.")
+
+    lines.append(f"Pontuação final: {result.score:.2f} (quanto menor, melhor)")
+    return "\n".join(lines)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Otimiza agenda de plantão a partir de um arquivo de configuração.")
+    parser.add_argument("config", type=Path, help="Arquivo JSON ou YAML com dados da escala.")
+    parser.add_argument("--iterations", type=int, default=400, help="Número de iterações da busca (padrão: 400).")
+    parser.add_argument("--seed", type=int, default=None, help="Semente opcional para reprodutibilidade.")
+    parser.add_argument("--dump-json", type=Path, help="Arquivo para salvar o resultado em JSON.")
+    parser.add_argument("--icloud-user", help="Apple ID (e-mail) para integração via CalDAV.")
+    parser.add_argument("--icloud-app-password", help="Senha específica de app gerada no iCloud.")
+    parser.add_argument("--icloud-calendar", help="Nome do calendário destino no iCloud.")
+    parser.add_argument(
+        "--icloud-server",
+        help="URL CalDAV do iCloud (padrão: https://caldav.icloud.com/).",
+    )
+    parser.add_argument(
+        "--icloud-timezone",
+        help="Timezone IANA (ex: America/Sao_Paulo) utilizado ao criar eventos.",
+    )
+    parser.add_argument(
+        "--icloud-keep-existing",
+        action="store_true",
+        help="Não remover eventos anteriores com o mesmo ID de plantão.",
+    )
+
+    args = parser.parse_args(argv)
+
+    config = load_configuration(args.config)
+    result = optimize_schedule(config, iterations=args.iterations, seed=args.seed)
+
+    print(_format_table(result))
+
+    if args.dump_json:
+        args.dump_json.write_text(
+            json.dumps(result.to_dict(), indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+
+    icloud_user = args.icloud_user or os.getenv("PLANTAO_ICLOUD_USER")
+    icloud_password = args.icloud_app_password or os.getenv("PLANTAO_ICLOUD_APP_PASSWORD")
+    icloud_calendar = args.icloud_calendar or os.getenv("PLANTAO_ICLOUD_CALENDAR")
+
+    if any([icloud_user, icloud_password, icloud_calendar]):
+        if not (icloud_user and icloud_password and icloud_calendar):
+            print(
+                "Para exportar ao iCloud informe usuário, senha específica de app e nome do calendário.",
+                file=sys.stderr,
+            )
+            return 2
+
+        icloud_server = args.icloud_server or os.getenv("PLANTAO_ICLOUD_SERVER", "https://caldav.icloud.com/")
+        timezone_name = args.icloud_timezone or os.getenv("PLANTAO_ICLOUD_TIMEZONE")
+        clear_existing = not args.icloud_keep_existing
+
+        try:
+            from .icloud import ICloudConfig, ICloudIntegrationError, connect, export_result
+
+            config_obj = ICloudConfig(
+                username=icloud_user,
+                app_password=icloud_password,
+                calendar=icloud_calendar,
+                server_url=icloud_server,
+            )
+            calendar = connect(config_obj)
+            created = export_result(
+                result,
+                calendar,
+                timezone_name=timezone_name,
+                clear_existing=clear_existing,
+            )
+            print(f"Eventos enviados ao iCloud: {created}")
+        except ICloudIntegrationError as exc:
+            print(f"Falha ao exportar para o iCloud: {exc}", file=sys.stderr)
+            return 2
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- extend optimization results to retain shift details and expose helper APIs for calendar export
- add an optional CalDAV-based integration module to push assignments into an iCloud calendar
- document setup and CLI usage, including new arguments for credentials and timezone handling

## Testing
- `python -m compileall plantao_optimizer`


------
https://chatgpt.com/codex/tasks/task_e_68e6d31b50808331969e2052087bc5b2